### PR TITLE
Bugfix not recording as mp client

### DIFF
--- a/NOBlackBox.csproj
+++ b/NOBlackBox.csproj
@@ -50,13 +50,13 @@
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Nuclear Option\NuclearOption_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>D:\SteamLibrary\steamapps\common\Nuclear Option\NuclearOption_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Mirage">
-      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Nuclear Option\NuclearOption_Data\Managed\Mirage.dll</HintPath>
+      <HintPath>D:\SteamLibrary\steamapps\common\Nuclear Option\NuclearOption_Data\Managed\Mirage.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/src/ACMI/ACMIFlare.cs
+++ b/src/ACMI/ACMIFlare.cs
@@ -51,9 +51,9 @@ namespace NOBlackBox
         }
         private string UpdatePosition(Vector3 newPos)
         {
-            string x = Mathf.Approximately(newPos.x, lastPos.x) ? "" : newPos.x.ToString("0.##", CultureInfo.InvariantCulture);
-            string y = Mathf.Approximately(newPos.y, lastPos.y) ? "" : newPos.y.ToString("0.##", CultureInfo.InvariantCulture);
-            string z = Mathf.Approximately(newPos.z, lastPos.z) ? "" : newPos.z.ToString("0.##", CultureInfo.InvariantCulture);
+            string x = Mathf.Approximately(newPos.x, lastPos.x) ? "" : newPos.x.ToString(CultureInfo.InvariantCulture);
+            string y = Mathf.Approximately(newPos.y, lastPos.y) ? "" : newPos.y.ToString(CultureInfo.InvariantCulture);
+            string z = Mathf.Approximately(newPos.z, lastPos.z) ? "" : newPos.z.ToString(CultureInfo.InvariantCulture);
 
             (float latitude, float longitude) = CartesianToGeodetic(newPos.x, newPos.z);
 

--- a/src/ACMI/ACMIMissile.cs
+++ b/src/ACMI/ACMIMissile.cs
@@ -65,7 +65,7 @@ namespace NOBlackBox
             bool isDetonated = (bool)typeof(Missile).GetField("detonated", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(unit);
             if (!Detonated && isDetonated)
             {
-                Plugin.Logger.LogDebug("Detonated");
+                Plugin.Logger?.LogDebug("Detonated");
                 Detonated = true;
                 FireEvent("LeftArea", [unit.persistentID], string.Empty);
             }

--- a/src/ACMI/ACMITracer.cs
+++ b/src/ACMI/ACMITracer.cs
@@ -49,9 +49,9 @@ namespace NOBlackBox
         }
         private string UpdatePosition(Vector3 newPos)
         {
-            string x = Mathf.Approximately(newPos.x, lastPos.x) ? "" : newPos.x.ToString("0.##", CultureInfo.InvariantCulture);
-            string y = Mathf.Approximately(newPos.y, lastPos.y) ? "" : newPos.y.ToString("0.##", CultureInfo.InvariantCulture);
-            string z = Mathf.Approximately(newPos.z, lastPos.z) ? "" : newPos.z.ToString("0.##", CultureInfo.InvariantCulture);
+            string x = Mathf.Approximately(newPos.x, lastPos.x) ? "" : newPos.x.ToString(CultureInfo.InvariantCulture);
+            string y = Mathf.Approximately(newPos.y, lastPos.y) ? "" : newPos.y.ToString(CultureInfo.InvariantCulture);
+            string z = Mathf.Approximately(newPos.z, lastPos.z) ? "" : newPos.z.ToString(CultureInfo.InvariantCulture);
 
             (float latitude, float longitude) = CartesianToGeodetic(newPos.x, newPos.z);
 

--- a/src/ACMI/ACMIUnit.cs
+++ b/src/ACMI/ACMIUnit.cs
@@ -52,17 +52,17 @@ namespace NOBlackBox
         }
         private string UpdatePosition(Vector3 newPos, Vector3 newRot)
         {
-            string x = Mathf.Approximately(newPos.x, lastPos.x) ? "" : newPos.x.ToString("0.##", CultureInfo.InvariantCulture);
-            string y = Mathf.Approximately(newPos.y, lastPos.y) ? "" : newPos.y.ToString("0.##", CultureInfo.InvariantCulture);
-            string z = Mathf.Approximately(newPos.z, lastPos.z) ? "" : newPos.z.ToString("0.##", CultureInfo.InvariantCulture);
+            string x = Mathf.Approximately(newPos.x, lastPos.x) ? "" : newPos.x.ToString(CultureInfo.InvariantCulture);
+            string y = Mathf.Approximately(newPos.y, lastPos.y) ? "" : newPos.y.ToString(CultureInfo.InvariantCulture);
+            string z = Mathf.Approximately(newPos.z, lastPos.z) ? "" : newPos.z.ToString(CultureInfo.InvariantCulture);
 
             float adjusted_roll = newRot.z > 180.0f ? 360 - newRot.z : -newRot.z;
             float adjusted_pitch = newRot.x > 180.0f ? 360 - newRot.x : -newRot.x;
             float adjusted_yaw = newRot.y;
 
-            string roll = Mathf.Approximately(newRot.z, lastRot.z) ? "" : adjusted_roll.ToString("0.##", CultureInfo.InvariantCulture);
-            string pitch = Mathf.Approximately(newRot.x, lastRot.x) ? "" : adjusted_pitch.ToString("0.##", CultureInfo.InvariantCulture);
-            string yaw = Mathf.Approximately(newRot.y, lastRot.y) ? "" : adjusted_yaw.ToString("0.##", CultureInfo.InvariantCulture);
+            string roll = Mathf.Approximately(newRot.z, lastRot.z) ? "" : adjusted_roll.ToString(CultureInfo.InvariantCulture);
+            string pitch = Mathf.Approximately(newRot.x, lastRot.x) ? "" : adjusted_pitch.ToString(CultureInfo.InvariantCulture);
+            string yaw = Mathf.Approximately(newRot.y, lastRot.y) ? "" : adjusted_yaw.ToString(CultureInfo.InvariantCulture);
 
             (float latitude, float longitude) = CartesianToGeodetic(newPos.x, newPos.z);
 

--- a/src/ACMI/ACMIWriter.cs
+++ b/src/ACMI/ACMIWriter.cs
@@ -46,11 +46,14 @@ namespace NOBlackBox
 
             Mission mission = MissionManager.CurrentMission;
             initProps.Add("Title", mission.Name.Replace(",", "\\,"));
-
-            //string briefing = mission.missionSettings.description.Replace(",", "\\,");
-            //if (briefing != "")
-            //    initProps.Add("Briefing", briefing);
-
+            /*
+            if (mission.missionSettings.description != null)
+            {
+                string briefing = mission.missionSettings.description.Replace(",", "\\,");
+                if (briefing != "")
+                    initProps.Add("Briefing", briefing);
+            }
+            */
             output.WriteLine($"0,{StringifyProps(initProps)}");
             output.Flush();
         }

--- a/src/ACMI/ACMIWriter.cs
+++ b/src/ACMI/ACMIWriter.cs
@@ -39,17 +39,17 @@ namespace NOBlackBox
             {
                 { "ReferenceTime", reference.ToString("s") + "Z" },
                 { "DataSource", $"Nuclear Option {Application.version}" },
-                { "DataRecorder", $"NOBlackBox" },
-                { "Author", GameManager.LocalPlayer.PlayerName.Replace(",", "\\,") },
+                { "DataRecorder", $"NOBlackBox 0.2.2" },
+                //{ "Author", GameManager.LocalPlayer.PlayerName.Replace(",", "\\,") },
                 { "RecordingTime", DateTime.Today.ToString("s") + "Z" },
             };
 
             Mission mission = MissionManager.CurrentMission;
             initProps.Add("Title", mission.Name.Replace(",", "\\,"));
 
-            string briefing = mission.missionSettings.description.Replace(",", "\\,");
-            if (briefing != "")
-                initProps.Add("Briefing", briefing);
+            //string briefing = mission.missionSettings.description.Replace(",", "\\,");
+            //if (briefing != "")
+            //    initProps.Add("Briefing", briefing);
 
             output.WriteLine($"0,{StringifyProps(initProps)}");
             output.Flush();

--- a/src/ACMI/ACMIWriter.cs
+++ b/src/ACMI/ACMIWriter.cs
@@ -40,7 +40,7 @@ namespace NOBlackBox
                 { "ReferenceTime", reference.ToString("s") + "Z" },
                 { "DataSource", $"Nuclear Option {Application.version}" },
                 { "DataRecorder", $"NOBlackBox 0.2.2" },
-                //{ "Author", GameManager.LocalPlayer.PlayerName.Replace(",", "\\,") },
+                { "Author", GameManager.LocalPlayer.PlayerName.Replace(",", "\\,") },
                 { "RecordingTime", DateTime.Today.ToString("s") + "Z" },
             };
 

--- a/src/LoadingManager/LoadingManager.cs
+++ b/src/LoadingManager/LoadingManager.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using Mirage;
+using NOBlackBox;
 using NuclearOption.Networking;
 using System;
 using System.Linq;
@@ -24,7 +25,7 @@ namespace NOBlackBox
             Type netManager = typeof(NetworkManagerNuclearOption);
             harmony.Patch(
                 netManager.GetMethod("Awake"),
-                null, 
+                null,
                 HookMethod(NetworkManagerPostfix)
             );
 
@@ -43,9 +44,9 @@ namespace NOBlackBox
 
         private static void MainMenuPostfix()
         {
-            Plugin.Logger.LogInfo("Reached GameLoaded");
+            Plugin.Logger?.LogDebug("Reached GameLoaded");
             GameLoaded?.Invoke();
-            
+
             MethodBase original = harmony.GetPatchedMethods().Where(a => a.DeclaringType == typeof(MainMenu)).First();
             harmony.Unpatch(original, HookMethod(MainMenuPostfix).method);
         }
@@ -55,13 +56,13 @@ namespace NOBlackBox
             NetworkManagerNuclearOption.i.Client.Connected.AddListener(ClientConnectCallback);
             NetworkManagerNuclearOption.i.Client.Disconnected.AddListener(ClientDisconectCallback);
 
-            Plugin.Logger.LogInfo("Reached NetworkReady");
+            Plugin.Logger?.LogDebug("Reached NetworkReady");
             NetworkReady?.Invoke();
         }
 
         private static void MissionLoadCallback()
         {
-            Plugin.Logger.LogInfo("Reached MissionLoaded");
+            Plugin.Logger?.LogDebug("Reached MissionLoaded");
             MissionLoaded?.Invoke();
         }
 
@@ -72,13 +73,13 @@ namespace NOBlackBox
 
         private static void ClientConnectCallback(INetworkPlayer player)
         {
-            if (GameManager.gameState == GameManager.GameState.Singleplayer || GameManager.gameState == GameManager.GameState.Multiplayer)
+            if (MissionManager.CurrentMission != null)
                 player.OnIdentityChanged += OnIdentity;
         }
 
         private static void ClientDisconectCallback(ClientStoppedReason reason)
         {
-            Plugin.Logger.LogInfo("Reached MissionUnloaded");
+            Plugin.Logger?.LogDebug("Reached MissionUnloaded");
             MissionUnloaded?.Invoke();
         }
     }

--- a/src/LoadingManager/LoadingManager.cs
+++ b/src/LoadingManager/LoadingManager.cs
@@ -43,7 +43,7 @@ namespace NOBlackBox
 
         private static void MainMenuPostfix()
         {
-            Plugin.Logger.LogDebug("Reached GameLoaded");
+            Plugin.Logger.LogInfo("Reached GameLoaded");
             GameLoaded?.Invoke();
             
             MethodBase original = harmony.GetPatchedMethods().Where(a => a.DeclaringType == typeof(MainMenu)).First();
@@ -55,13 +55,13 @@ namespace NOBlackBox
             NetworkManagerNuclearOption.i.Client.Connected.AddListener(ClientConnectCallback);
             NetworkManagerNuclearOption.i.Client.Disconnected.AddListener(ClientDisconectCallback);
 
-            Plugin.Logger.LogDebug("Reached NetworkReady");
+            Plugin.Logger.LogInfo("Reached NetworkReady");
             NetworkReady?.Invoke();
         }
 
         private static void MissionLoadCallback()
         {
-            Plugin.Logger.LogDebug("Reached MissionLoaded");
+            Plugin.Logger.LogInfo("Reached MissionLoaded");
             MissionLoaded?.Invoke();
         }
 
@@ -78,7 +78,7 @@ namespace NOBlackBox
 
         private static void ClientDisconectCallback(ClientStoppedReason reason)
         {
-            Plugin.Logger.LogDebug("Reached MissionUnloaded");
+            Plugin.Logger.LogInfo("Reached MissionUnloaded");
             MissionUnloaded?.Invoke();
         }
     }

--- a/src/Plugin/Plugin.cs
+++ b/src/Plugin/Plugin.cs
@@ -3,6 +3,7 @@ using BepInEx.Logging;
 using UnityEngine;
 using NuclearOption.SavedMission;
 using System;
+using System.Threading.Tasks;
 
 #if BEP6
 using BepInEx.Unity.Mono;
@@ -44,8 +45,20 @@ namespace NOBlackBox
                 timer = 0f;
             }
         }
-        private void OnMissionLoad()
+
+        private async Task<bool> WaitForLocalPlayer()
         {
+            while(GameManager.LocalPlayer == null)
+            {
+                Logger?.LogInfo("[NOBlackBox]: Waiting for LocalPlayer...");
+                await Task.Delay(100);
+            }
+            return true;
+        }
+
+        private async void OnMissionLoad()
+        {
+            await WaitForLocalPlayer();
             Logger?.LogInfo("[NOBlackBox]: MISSION LOADED.");
             recorder = new Recorder(MissionManager.CurrentMission);
         }

--- a/src/Plugin/Plugin.cs
+++ b/src/Plugin/Plugin.cs
@@ -15,9 +15,8 @@ namespace NOBlackBox
     [BepInProcess("NuclearOption.exe")]
     internal class Plugin : BaseUnityPlugin
     {
-        internal static new ManualLogSource Logger;
+        internal static new ManualLogSource ?Logger;
         private Recorder? recorder;
-        private int ticker = 0;
         private float waitTime = 0.2f;
         private float timer = 0f;
 
@@ -25,13 +24,13 @@ namespace NOBlackBox
         {
             Logger = base.Logger;
 
-            MissionManager.onMissionStart += OnMissionLoad;
+            LoadingManager.MissionLoaded += OnMissionLoad;
             LoadingManager.MissionUnloaded += OnMissionUnload;
         }
         private void Awake()
         {
             Configuration.InitSettings(Config);
-            Logger.LogInfo("[NOBlackBox]: LOADED.");
+            Logger?.LogInfo("[NOBlackBox]: LOADED.");
 
             waitTime = 1f / Configuration.UpdateRate.Value;
             waitTime = MathF.Round(waitTime, 3);
@@ -45,14 +44,14 @@ namespace NOBlackBox
                 timer = 0f;
             }
         }
-        private void OnMissionLoad(Mission mission)
+        private void OnMissionLoad()
         {
-            Logger.LogInfo("[NOBlackBox]: MISSION LOADED.");
-            recorder = new Recorder(mission);
+            Logger?.LogInfo("[NOBlackBox]: MISSION LOADED.");
+            recorder = new Recorder(MissionManager.CurrentMission);
         }
         private void OnMissionUnload()
         {
-            Logger.LogInfo("[NOBlackBox]: MISSION UNLOADED.");
+            Logger?.LogInfo("[NOBlackBox]: MISSION UNLOADED.");
             recorder?.Close();
             recorder = null;
         }

--- a/src/Plugin/Plugin.cs
+++ b/src/Plugin/Plugin.cs
@@ -41,7 +41,7 @@ namespace NOBlackBox
             timer += Time.deltaTime;
             if (recorder != null && timer >= waitTime)
             {
-                recorder?.Update(timer);
+                recorder.Update(timer);
                 timer = 0f;
             }
         }

--- a/src/Plugin/Plugin.cs
+++ b/src/Plugin/Plugin.cs
@@ -48,7 +48,9 @@ namespace NOBlackBox
 
         private async Task<bool> WaitForLocalPlayer()
         {
-            while(GameManager.LocalPlayer == null)
+            Logger?.LogInfo("[NOBlackBox]: TRYING TO GET PLAYERNAME...");
+            Logger?.LogInfo($"[NOBlackBox]: {GameManager.LocalPlayer.PlayerName}");
+            while (GameManager.LocalPlayer.PlayerName == null)
             {
                 Logger?.LogInfo("[NOBlackBox]: Waiting for LocalPlayer...");
                 await Task.Delay(100);

--- a/src/Recorder/Recorder.cs
+++ b/src/Recorder/Recorder.cs
@@ -28,12 +28,12 @@ namespace NOBlackBox
             curTime = startDate;
 
             writer = new ACMIWriter(startDate);
-            Plugin.Logger.LogInfo("[NOBlackBox]: RECORDING STARTED");
+            Plugin.Logger?.LogInfo("[NOBlackBox]: RECORDING STARTED");
         }
 
         ~Recorder()
         {
-            Plugin.Logger.LogInfo("[NOBlackBox]: RECORDING ENDED");
+            Plugin.Logger?.LogInfo("[NOBlackBox]: RECORDING ENDED");
             Close();
         }
 
@@ -54,19 +54,19 @@ namespace NOBlackBox
                     flares.Remove(acmi);
                     writer.RemoveObject(acmi, curTime);
                 }
-            /*
+
             foreach (var acmi in tracers.Values.ToList())
                 if (acmi.bullet.tracer == null || !acmi.bullet.tracer.activeSelf) // Apparently we can lose references? wtf?
                 {
                     tracers.Remove(acmi.bullet);
                     writer.RemoveObject(acmi, curTime);
                 }
-            */
+
             Unit[] units = UnityEngine.Object.FindObjectsByType<Unit>(FindObjectsSortMode.None);
 
             foreach (var unit in units)
             {
-                if (!unit.networked || unit.disabled)
+                if (!unit.networked || unit.disabled || unit.persistentID == 0)
                     continue;
 
                 bool isNew = false;
@@ -111,7 +111,7 @@ namespace NOBlackBox
                     props = props.Concat(acmi.Init()).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
                 if (unit.IsLocalPlayer)
-                    Plugin.Logger.LogInfo(props["T"]);
+                    Plugin.Logger?.LogInfo(props["T"]);
 
                 writer.UpdateObject(acmi, curTime, props);
             }
@@ -128,7 +128,7 @@ namespace NOBlackBox
 
             flares.AddRange(newFlare);
             newFlare.Clear();
-            /*
+
             var bulletSims = UnityEngine.Object.FindObjectsByType<BulletSim>(FindObjectsSortMode.None);
             
             foreach (var bulletSim in bulletSims)
@@ -156,7 +156,7 @@ namespace NOBlackBox
             }
 
             newTracers.Clear();
-            */
+
             writer.Flush();
         }
 

--- a/src/Recorder/Recorder.cs
+++ b/src/Recorder/Recorder.cs
@@ -28,10 +28,12 @@ namespace NOBlackBox
             curTime = startDate;
 
             writer = new ACMIWriter(startDate);
+            Plugin.Logger.LogInfo("[NOBlackBox]: RECORDING STARTED");
         }
 
         ~Recorder()
         {
+            Plugin.Logger.LogInfo("[NOBlackBox]: RECORDING ENDED");
             Close();
         }
 
@@ -52,14 +54,14 @@ namespace NOBlackBox
                     flares.Remove(acmi);
                     writer.RemoveObject(acmi, curTime);
                 }
-
+            /*
             foreach (var acmi in tracers.Values.ToList())
                 if (acmi.bullet.tracer == null || !acmi.bullet.tracer.activeSelf) // Apparently we can lose references? wtf?
                 {
                     tracers.Remove(acmi.bullet);
                     writer.RemoveObject(acmi, curTime);
                 }
-
+            */
             Unit[] units = UnityEngine.Object.FindObjectsByType<Unit>(FindObjectsSortMode.None);
 
             foreach (var unit in units)
@@ -126,9 +128,9 @@ namespace NOBlackBox
 
             flares.AddRange(newFlare);
             newFlare.Clear();
-
+            /*
             var bulletSims = UnityEngine.Object.FindObjectsByType<BulletSim>(FindObjectsSortMode.None);
-
+            
             foreach (var bulletSim in bulletSims)
             {
                 List<BulletSim.Bullet> bullets = (List<BulletSim.Bullet>)Recorder.bullets.GetValue(bulletSim);
@@ -141,7 +143,7 @@ namespace NOBlackBox
                     }
                 }
             }
-
+            
             foreach (ACMITracer tracer in tracers.Values)
                 writer.UpdateObject(tracer, curTime, tracer.Update());
 
@@ -154,7 +156,7 @@ namespace NOBlackBox
             }
 
             newTracers.Clear();
-
+            */
             writer.Flush();
         }
 


### PR DESCRIPTION
recorder was inaccessible due to loading manager issues

upon fixing them, it came to light that the acmiwriter initProps throws null reference errors due to not finding GameManager.LocalPlayer.PlayerName

added an async method to wait for that info to be available before attempting to init the recorder.