### PR TITLE
Add Real-Time Telemetry (RTT) server for Tacview live streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
+# Local build overrides (contains machine-specific paths)
+Directory.Build.props
+
 # User-specific files
 *.rsuser
 *.suo

--- a/NOBlackBox.csproj
+++ b/NOBlackBox.csproj
@@ -57,16 +57,20 @@
 
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\Program Files (x86)\Steam\steamapps\common\Nuclear Option\NuclearOption_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath Condition="'$(NUCLEAR_OPTION_ROOT)' == ''">..\..\Program Files (x86)\Steam\steamapps\common\Nuclear Option\NuclearOption_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath Condition="'$(NUCLEAR_OPTION_ROOT)' != ''">$(NUCLEAR_OPTION_ROOT)\NuclearOption_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>..\..\Program Files (x86)\Steam\steamapps\common\Nuclear Option\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath Condition="'$(NUCLEAR_OPTION_ROOT)' == ''">..\..\Program Files (x86)\Steam\steamapps\common\Nuclear Option\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath Condition="'$(NUCLEAR_OPTION_ROOT)' != ''">$(NUCLEAR_OPTION_ROOT)\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="Mirage">
-      <HintPath>..\..\Program Files (x86)\Steam\steamapps\common\Nuclear Option\NuclearOption_Data\Managed\Mirage.dll</HintPath>
+      <HintPath Condition="'$(NUCLEAR_OPTION_ROOT)' == ''">..\..\Program Files (x86)\Steam\steamapps\common\Nuclear Option\NuclearOption_Data\Managed\Mirage.dll</HintPath>
+      <HintPath Condition="'$(NUCLEAR_OPTION_ROOT)' != ''">$(NUCLEAR_OPTION_ROOT)\NuclearOption_Data\Managed\Mirage.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>..\..\Program Files (x86)\Steam\steamapps\common\Nuclear Option\NuclearOption_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath Condition="'$(NUCLEAR_OPTION_ROOT)' == ''">..\..\Program Files (x86)\Steam\steamapps\common\Nuclear Option\NuclearOption_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath Condition="'$(NUCLEAR_OPTION_ROOT)' != ''">$(NUCLEAR_OPTION_ROOT)\NuclearOption_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/src/ACMIWriter/ACMIWriter.cs
+++ b/src/ACMIWriter/ACMIWriter.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -35,13 +36,20 @@ namespace NOBlackBox
                 filename = basename + $" ({++postfix}).acmi";
 
             output = new MultiThreadedStreamWriter(File.CreateText(filename));
-            //sb = new StringBuilder();
             this.reference = reference;
             currentMapKey = MapSettingsManager.i.MapLoader.CurrentMap;
 
             Plugin.Logger?.LogDebug("MAP NAME IS " + currentMapKey.Path);
-            output.WriteLine("FileType=text/acmi/tacview");
-            output.WriteLine("FileVersion=2.2");
+
+            Plugin.rttServer?.BeginSession();
+
+            string fileTypeLine = "FileType=text/acmi/tacview";
+            output.WriteLine(fileTypeLine);
+            Plugin.rttServer?.PublishLine(fileTypeLine, replay: true);
+
+            string fileVerLine = "FileVersion=2.2";
+            output.WriteLine(fileVerLine);
+            Plugin.rttServer?.PublishLine(fileVerLine, replay: true);
 
             Dictionary<string, string> initProps = new()
             {
@@ -55,16 +63,10 @@ namespace NOBlackBox
 
             Mission mission = MissionManager.CurrentMission;
             initProps.Add("Title", mission.Name.Replace(",", "\\,"));
-            
-            /*
-            if (mission.missionSettings.description != null)
-            {
-                string briefing = mission.missionSettings.description.Replace(",", "\\,");
-                if (briefing != "")
-                    initProps.Add("Briefing", briefing);
-            }
-            */
-            output.WriteLine($"0,{StringifyProps(initProps)}");
+
+            string metadataLine = $"0,{StringifyProps(initProps)}";
+            output.WriteLine(metadataLine);
+            Plugin.rttServer?.PublishLine(metadataLine, replay: true);
             output.Flush();
 
             lastFlushTime = DateTime.Now;
@@ -155,14 +157,19 @@ namespace NOBlackBox
 
         internal void WriteLine(string line)
         {
+            if (line.StartsWith("#"))
+            {
+                Plugin.rttServer?.PublishFlushMarker();
+            }
+
             if ((DateTime.Now - lastFlushTime).TotalSeconds > Configuration.AutoSaveInterval)
             {
                 output.Flush();
                 lastFlushTime = DateTime.Now;
-                //output.Close();
-                //output = new StreamWriter(filename, append: true);
             }
             output.WriteLine(line);
+
+            Plugin.rttServer?.PublishLine(line, replay: false);
         }
 
         internal void Flush()
@@ -170,8 +177,15 @@ namespace NOBlackBox
             output.Flush();
         }
 
+        private int _closed;
+
         internal async void Close()
         {
+            if (Interlocked.Exchange(ref _closed, 1) == 1)
+                return;
+
+            Plugin.rttServer?.EndSession(disconnectClients: true);
+
             output.Close();
             string zipPath = await ZipHelper.ZipFileAsync(filename);
             Plugin.Logger?.LogDebug($"saving compressed acmi {zipPath}");

--- a/src/Configuration/Configuration.cs
+++ b/src/Configuration/Configuration.cs
@@ -42,6 +42,22 @@ namespace NOBlackBox
         internal const bool DefaultRecordExtraTelemetry = true;
 
         internal const bool DefaultEnableLogging = false;
+
+        internal const string LiveTelemetrySettings = "Real-Time Telemetry";
+
+        internal const bool DefaultLiveTelemetryEnabled = false;
+        internal const string DefaultLiveTelemetryBindAddress = "127.0.0.1";
+        internal const int DefaultLiveTelemetryPort = 42674;
+        internal const string DefaultLiveTelemetryPassword = "";
+        internal const int DefaultLiveTelemetryMaxClients = 4;
+        internal const int DefaultLiveTelemetryClientQueueLimit = 5000;
+
+        internal static ConfigEntry<bool> LiveTelemetryEnabled;
+        internal static ConfigEntry<string> LiveTelemetryBindAddress;
+        internal static ConfigEntry<int> LiveTelemetryPort;
+        internal static ConfigEntry<string> LiveTelemetryPassword;
+        internal static ConfigEntry<int> LiveTelemetryMaxClients;
+        internal static ConfigEntry<int> LiveTelemetryClientQueueLimit;
         
         internal const KeyCode DefaultGenerateHeightMapKey = KeyCode.F10;
         internal const int DefaultMetersPerScan = 4;
@@ -420,6 +436,32 @@ namespace NOBlackBox
 
             EnableLogging = config.Bind(DeveloperFeatures, "EnableLogging", DefaultEnableLogging, "Toggle Logging. Default: false");
             Plugin.Logger?.LogDebug($"EnableLogging = {EnableLogging.Value}");
+
+            LiveTelemetryEnabled = config.Bind(LiveTelemetrySettings, "LiveTelemetryEnabled",
+                DefaultLiveTelemetryEnabled, "Enable Real-Time Telemetry server.");
+            Plugin.Logger?.LogDebug($"LiveTelemetryEnabled = {LiveTelemetryEnabled.Value}");
+
+            LiveTelemetryBindAddress = config.Bind(LiveTelemetrySettings, "LiveTelemetryBindAddress",
+                DefaultLiveTelemetryBindAddress,
+                "IP address to bind. Use 0.0.0.0 for all interfaces (network access).");
+            Plugin.Logger?.LogDebug($"LiveTelemetryBindAddress = {LiveTelemetryBindAddress.Value}");
+
+            LiveTelemetryPort = config.Bind(LiveTelemetrySettings, "LiveTelemetryPort",
+                DefaultLiveTelemetryPort, "TCP port for Real-Time Telemetry (default 42674).");
+            Plugin.Logger?.LogDebug($"LiveTelemetryPort = {LiveTelemetryPort.Value}");
+
+            LiveTelemetryPassword = config.Bind(LiveTelemetrySettings, "LiveTelemetryPassword",
+                DefaultLiveTelemetryPassword, "RTT password (uses CRC-64-ECMA over UTF-16LE).");
+            Plugin.Logger?.LogDebug($"LiveTelemetryPassword = {LiveTelemetryPassword.Value}");
+
+            LiveTelemetryMaxClients = config.Bind(LiveTelemetrySettings, "LiveTelemetryMaxClients",
+                DefaultLiveTelemetryMaxClients, "Maximum concurrent Tacview client connections.");
+            Plugin.Logger?.LogDebug($"LiveTelemetryMaxClients = {LiveTelemetryMaxClients.Value}");
+
+            LiveTelemetryClientQueueLimit = config.Bind(LiveTelemetrySettings, "LiveTelemetryClientQueueLimit",
+                DefaultLiveTelemetryClientQueueLimit,
+                "Max queued lines per client before disconnect (per-client).");
+            Plugin.Logger?.LogDebug($"LiveTelemetryClientQueueLimit = {LiveTelemetryClientQueueLimit.Value}");
 
         }
     }

--- a/src/Helpers/Helpers.cs
+++ b/src/Helpers/Helpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace NOBlackBox
 {
@@ -29,6 +30,33 @@ namespace NOBlackBox
             float longitude = U * 180 / longArc;
 
             return (latitude, longitude);
+        }
+
+        internal static ulong ComputeTacviewPasswordCrc64(string input)
+        {
+            const ulong poly = 0x42F0E1EBA9EA3693UL;
+            byte[] bytes = Encoding.Unicode.GetBytes(input);
+            ulong crc = 0xFFFFFFFFFFFFFFFFUL;
+
+            foreach (byte b in bytes)
+            {
+                crc ^= (ulong)b << 56;
+                for (int i = 0; i < 8; i++)
+                {
+                    crc = (crc & 0x8000000000000000UL) != 0
+                        ? (crc << 1) ^ poly
+                        : crc << 1;
+                }
+            }
+
+            return crc ^ 0xFFFFFFFFFFFFFFFFUL;
+        }
+
+        internal static string ComputePasswordHash(string? password)
+        {
+            if (string.IsNullOrEmpty(password))
+                return "0";
+            return ComputeTacviewPasswordCrc64(password).ToString("x16");
         }
     }
 }

--- a/src/Plugin/Plugin.cs
+++ b/src/Plugin/Plugin.cs
@@ -36,6 +36,8 @@ namespace NOBlackBox
 
         private Action? OnGameStateChange;
 
+        internal static RTTTelemetryServer? rttServer;
+
         internal static Dictionary<string, List<string>> aircraftInfo;
         internal static Dictionary<string, List<string>> groundInfo;
         internal static Dictionary<string, List<string>> missileInfo;
@@ -69,6 +71,30 @@ namespace NOBlackBox
             if (Configuration.EnableLogging.Value == true)
             {
                 Logger = base.Logger;
+            }
+
+            if (Configuration.LiveTelemetryEnabled.Value)
+            {
+                try
+                {
+                    rttServer = new RTTTelemetryServer(
+                        Configuration.LiveTelemetryPort.Value,
+                        Configuration.LiveTelemetryBindAddress.Value,
+                        Configuration.LiveTelemetryMaxClients.Value,
+                        Configuration.LiveTelemetryClientQueueLimit.Value,
+                        Configuration.LiveTelemetryPassword.Value,
+                        Logger
+                    );
+                    rttServer.Start();
+                    Logger?.LogInfo($"RTT server started on " +
+                        $"{Configuration.LiveTelemetryBindAddress.Value}:" +
+                        $"{Configuration.LiveTelemetryPort.Value}");
+                }
+                catch (Exception ex)
+                {
+                    Logger?.LogError($"Failed to start RTT server: {ex.Message}");
+                    rttServer = null;
+                }
             }
 
             foreach (string key in NOBlackBoxUnitInfo.Keys)
@@ -188,6 +214,12 @@ namespace NOBlackBox
             {
                 GameObject.Destroy(obj);
             }
+        }
+
+        private void OnDestroy()
+        {
+            rttServer?.Dispose();
+            rttServer = null;
         }
 
         private void ResetRecordingManually()

--- a/src/RTTTelemetryServer/RTTClient.cs
+++ b/src/RTTTelemetryServer/RTTClient.cs
@@ -1,0 +1,337 @@
+using BepInEx.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NOBlackBox
+{
+    internal class RttMessage
+{
+    internal static readonly RttMessage FlushMessage = new(null, true);
+
+    public string? Line { get; }
+    public bool Flush { get; }
+
+    public RttMessage(string? line, bool flush)
+    {
+        Line = line;
+        Flush = flush;
+    }
+}
+
+    internal class RTTClient
+    {
+        private readonly TcpClient _tcpClient;
+        private readonly NetworkStream _stream;
+        private readonly string _endpoint;
+        private readonly RTTTelemetryServer _server;
+        private readonly Guid _id;
+        private readonly int _queueLimit;
+        private readonly int _handshakeTimeoutMs;
+        private readonly int _maxHandshakeBytes;
+        private readonly string _password;
+        private readonly ManualLogSource? _logger;
+
+        private readonly ConcurrentQueue<RttMessage> _queue = new();
+        private int _queuedCount;
+        private int _disconnectRequested;
+        private CancellationTokenSource _cts;
+        private Task? _writerTask;
+
+        internal Guid Id => _id;
+        internal string Endpoint => _endpoint;
+
+        internal RTTClient(
+            TcpClient tcpClient,
+            RTTTelemetryServer server,
+            Guid id,
+            int queueLimit,
+            string password,
+            ManualLogSource? logger)
+        {
+            _tcpClient = tcpClient;
+            _tcpClient.NoDelay = true;
+            _stream = tcpClient.GetStream();
+            _endpoint = tcpClient.Client.RemoteEndPoint?.ToString() ?? "unknown";
+            _server = server;
+            _id = id;
+            _queueLimit = queueLimit;
+            _handshakeTimeoutMs = 5000;
+            _maxHandshakeBytes = 4096;
+            _password = password;
+            _logger = logger;
+            _cts = new CancellationTokenSource();
+        }
+
+        internal async Task<bool> PerformHandshakeAsync()
+        {
+            try
+            {
+                using var timeoutCts = new CancellationTokenSource(_handshakeTimeoutMs);
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    timeoutCts.Token, _cts.Token);
+                var ct = linkedCts.Token;
+
+                // Host sends first: protocol greeting
+                byte[] hostGreeting = Encoding.UTF8.GetBytes(
+                    "XtraLib.Stream.0\nTacview.RealTimeTelemetry.0\nNOBlackBox\n\0");
+                await _stream.WriteAsync(hostGreeting, 0, hostGreeting.Length, ct);
+                await _stream.FlushAsync(ct);
+
+                // Client responds with protocol + username + password hash
+                byte[] response = await ReadUntilNullAsync(_maxHandshakeBytes, ct);
+                if (response == null)
+                {
+                    _logger?.LogWarning($"RTT handshake: {_endpoint} sent no response");
+                    return false;
+                }
+
+                string[] fields = Encoding.UTF8.GetString(response).Split('\n');
+                if (fields.Length != 4)
+                {
+                    _logger?.LogWarning(
+                        $"RTT handshake: {_endpoint} sent {fields.Length} fields, expected 4");
+                    return false;
+                }
+
+                if (fields[0] != "XtraLib.Stream.0" ||
+                    fields[1] != "Tacview.RealTimeTelemetry.0")
+                {
+                    _logger?.LogWarning(
+                        $"RTT handshake: {_endpoint} protocol mismatch " +
+                        $"({fields[0]}, {fields[1]})");
+                    return false;
+                }
+
+                string username = fields[2];
+                foreach (char c in username)
+                {
+                    if (c <= 0x1F && c != '\t')
+                    {
+                        _logger?.LogWarning(
+                            $"RTT handshake: {_endpoint} username contains " +
+                            $"control character 0x{(int)c:X2}");
+                        return false;
+                    }
+                }
+
+                string clientHash = fields[3];
+
+                if (!string.IsNullOrEmpty(_password))
+                {
+                    string expectedHash = Helpers.ComputePasswordHash(_password);
+                    if (!string.Equals(clientHash, expectedHash,
+                        StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger?.LogWarning(
+                            $"RTT handshake: {_endpoint} password mismatch " +
+                            $"(expected {expectedHash}, got {clientHash})");
+                        return false;
+                    }
+                }
+
+                _logger?.LogInfo(
+                    $"RTT client connected: {username} ({_endpoint})");
+
+                return true;
+            }
+            catch (OperationCanceledException)
+            {
+                _logger?.LogWarning(
+                    $"RTT handshake: {_endpoint} timed out");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(
+                    $"RTT handshake: {_endpoint} error: {ex.Message}");
+                return false;
+            }
+        }
+
+        private async Task<byte[]?> ReadUntilNullAsync(int maxBytes, CancellationToken ct)
+        {
+            using var ms = new MemoryStream(maxBytes);
+            byte[] buf = new byte[1];
+            int total = 0;
+
+            while (total < maxBytes)
+            {
+                int read = await _stream.ReadAsync(buf, 0, 1, ct);
+                if (read == 0)
+                    return null;
+
+                total++;
+                if (buf[0] == 0)
+                    break;
+
+                ms.WriteByte(buf[0]);
+            }
+
+            return ms.ToArray();
+        }
+
+        internal void StartWriter(List<string> replayPrefix)
+        {
+            foreach (var line in replayPrefix)
+            {
+                _queue.Enqueue(new RttMessage(line, false));
+                Interlocked.Increment(ref _queuedCount);
+            }
+
+            _writerTask = Task.Run(() => WriterLoop(_cts.Token));
+        }
+
+        private async Task WriterLoop(CancellationToken ct)
+        {
+            try
+            {
+                var writer = new StreamWriter(
+                    _stream,
+                    new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                    bufferSize: 8192,
+                    leaveOpen: true
+                )
+                {
+                    NewLine = "\n",
+                    AutoFlush = false
+                };
+
+                while (!ct.IsCancellationRequested)
+                {
+                    if (_queue.TryDequeue(out var msg))
+                    {
+                        Interlocked.Decrement(ref _queuedCount);
+
+                        if (msg.Flush)
+                        {
+                            await writer.FlushAsync();
+                        }
+                        else if (msg.Line != null)
+                        {
+                            await writer.WriteAsync(msg.Line);
+                            await writer.WriteAsync('\n');
+                        }
+                    }
+                    else
+                    {
+                        try
+                        {
+                            await Task.Delay(10, ct);
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                await writer.FlushAsync();
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(
+                    $"RTT writer: {_endpoint} error: {ex.Message}");
+            }
+            finally
+            {
+                CleanupSocket();
+                _server.RemoveClient(_id);
+            }
+        }
+
+        internal bool TryEnqueue(RttMessage msg)
+        {
+            if (_disconnectRequested != 0)
+                return false;
+
+            if (Interlocked.Increment(ref _queuedCount) > _queueLimit)
+            {
+                Interlocked.Decrement(ref _queuedCount);
+                _logger?.LogWarning(
+                    $"RTT client queue full ({_endpoint}), disconnecting");
+                RequestDisconnect("queue overflow");
+                return false;
+            }
+
+            _queue.Enqueue(msg);
+            return true;
+        }
+
+        internal void RequestDisconnect(string reason)
+        {
+            if (Interlocked.Exchange(ref _disconnectRequested, 1) != 0)
+                return;
+
+            _ = Task.Run(() => DisconnectAsync(reason, graceful: true));
+        }
+
+        private async Task DisconnectAsync(string reason, bool graceful)
+        {
+            try
+            {
+                if (graceful)
+                {
+                    EnqueueBestEffort(new RttMessage(null, true));
+                    await DrainForAsync(TimeSpan.FromSeconds(1));
+                }
+
+                _logger?.LogInfo(
+                    $"RTT client disconnected: {_endpoint} ({reason})");
+            }
+            catch { }
+            finally
+            {
+                _cts.Cancel();
+                _server.RemoveClient(_id);
+            }
+        }
+
+        private void EnqueueBestEffort(RttMessage msg)
+        {
+            Interlocked.Increment(ref _queuedCount);
+            _queue.Enqueue(msg);
+        }
+
+        private async Task DrainForAsync(TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline && !_queue.IsEmpty)
+            {
+                await Task.Delay(10);
+            }
+        }
+
+        private void CleanupSocket()
+        {
+            try
+            {
+                _tcpClient.Close();
+            }
+            catch { }
+        }
+
+        internal async Task CleanShutdownAsync()
+        {
+            if (Interlocked.Exchange(ref _disconnectRequested, 1) != 0)
+                return;
+
+            EnqueueBestEffort(new RttMessage(null, true));
+            await DrainForAsync(TimeSpan.FromSeconds(1));
+            _cts.Cancel();
+            if (_writerTask != null)
+            {
+                try { await _writerTask; }
+                catch { }
+            }
+            CleanupSocket();
+            _server.RemoveClient(_id);
+        }
+    }
+}

--- a/src/RTTTelemetryServer/RTTTelemetryServer.cs
+++ b/src/RTTTelemetryServer/RTTTelemetryServer.cs
@@ -1,0 +1,210 @@
+using BepInEx.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NOBlackBox
+{
+    internal class RTTTelemetryServer : IDisposable
+    {
+        private readonly int _port;
+        private readonly string _bindAddress;
+        private readonly int _maxClients;
+        private readonly int _clientQueueLimit;
+        private readonly string _password;
+        private readonly ManualLogSource? _logger;
+
+        private TcpListener? _listener;
+        private CancellationTokenSource _cts;
+        private ConcurrentDictionary<Guid, RTTClient> _clients = new();
+        private List<string> _replayPrefix = new();
+        private readonly object _sessionLock = new();
+        private int _activeConnections;
+
+        internal RTTTelemetryServer(
+            int port,
+            string bindAddress,
+            int maxClients,
+            int clientQueueLimit,
+            string password,
+            ManualLogSource? logger)
+        {
+            _port = port;
+            _bindAddress = bindAddress;
+            _maxClients = maxClients;
+            _clientQueueLimit = clientQueueLimit;
+            _password = password;
+            _logger = logger;
+            _cts = new CancellationTokenSource();
+        }
+
+        internal void Start()
+        {
+            var addr = string.IsNullOrEmpty(_bindAddress) || _bindAddress == "0.0.0.0"
+                ? IPAddress.Any
+                : IPAddress.Parse(_bindAddress);
+
+            _listener = new TcpListener(addr, _port);
+            _listener.Start();
+            _ = Task.Run(() => AcceptLoop(_cts.Token));
+        }
+
+        internal void Stop()
+        {
+            _cts.Cancel();
+            try { _listener?.Stop(); } catch { }
+        }
+
+        public void Dispose()
+        {
+            Stop();
+
+            foreach (var kvp in _clients)
+            {
+                kvp.Value.RequestDisconnect("server shutdown");
+            }
+
+            _clients.Clear();
+        }
+
+        private async Task AcceptLoop(CancellationToken ct)
+        {
+            try
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    TcpClient tcpClient;
+                    try
+                    {
+                        tcpClient = await _listener!.AcceptTcpClientAsync();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger?.LogWarning($"RTT accept error: {ex.Message}");
+                        continue;
+                    }
+
+                    _ = HandleClientAsync(tcpClient);
+                }
+            }
+            catch (OperationCanceledException) { }
+        }
+
+        private async Task HandleClientAsync(TcpClient tcpClient)
+        {
+            string endpoint = tcpClient.Client.RemoteEndPoint?.ToString() ?? "unknown";
+
+            if (Interlocked.Increment(ref _activeConnections) > _maxClients)
+            {
+                Interlocked.Decrement(ref _activeConnections);
+                _logger?.LogWarning($"RTT max clients ({_maxClients}) reached, rejecting {endpoint}");
+                tcpClient.Close();
+                return;
+            }
+
+            var client = new RTTClient(
+                tcpClient,
+                this,
+                Guid.NewGuid(),
+                _clientQueueLimit,
+                _password,
+                _logger);
+
+            try
+            {
+                bool handshakeOk = await client.PerformHandshakeAsync();
+                if (!handshakeOk)
+                {
+                    Interlocked.Decrement(ref _activeConnections);
+                    tcpClient.Close();
+                    return;
+                }
+
+                List<string> prefixSnapshot;
+                lock (_sessionLock)
+                {
+                    prefixSnapshot = new List<string>(_replayPrefix);
+                    _clients.TryAdd(client.Id, client);
+                }
+
+                client.StartWriter(prefixSnapshot);
+
+                _logger?.LogInfo($"RTT client registered: {endpoint}");
+            }
+            catch (Exception ex)
+            {
+                Interlocked.Decrement(ref _activeConnections);
+                _logger?.LogWarning($"RTT client setup error: {endpoint}: {ex.Message}");
+                tcpClient.Close();
+            }
+        }
+
+        internal void RemoveClient(Guid id)
+        {
+            if (_clients.TryRemove(id, out _))
+            {
+                Interlocked.Decrement(ref _activeConnections);
+            }
+        }
+
+        internal void BeginSession()
+        {
+            lock (_sessionLock)
+            {
+                _replayPrefix.Clear();
+            }
+        }
+
+        internal void PublishLine(string line, bool replay)
+        {
+            var msg = new RttMessage(line, false);
+
+            if (replay)
+            {
+                lock (_sessionLock)
+                {
+                    _replayPrefix.Add(line);
+                }
+            }
+
+            foreach (var kvp in _clients)
+            {
+                kvp.Value.TryEnqueue(msg);
+            }
+        }
+
+        internal void PublishFlushMarker()
+        {
+            foreach (var kvp in _clients)
+            {
+                kvp.Value.TryEnqueue(RttMessage.FlushMessage);
+            }
+        }
+
+        internal void EndSession(bool disconnectClients)
+        {
+            List<RTTClient> snapshot;
+            lock (_sessionLock)
+            {
+                snapshot = new List<RTTClient>(_clients.Values);
+                _replayPrefix.Clear();
+            }
+
+            if (disconnectClients)
+            {
+                foreach (var client in snapshot)
+                {
+                    client.RequestDisconnect("session end");
+                }
+            }
+        }
+    }
+}

--- a/test_rtt_client.py
+++ b/test_rtt_client.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""test_rtt_client.py — smoke test for NOBlackBox RTT
+
+Usage:
+  # Test no-password mode (default config)
+  python3 test_rtt_client.py
+
+  # Test password-protected mode (server must have password set)
+  python3 test_rtt_client.py --password mysecret
+
+Reads until required header lines appear or timeout — no fixed sleep.
+"""
+import socket, sys, time, argparse
+
+HOST = "127.0.0.1"
+PORT = 42674
+
+def crc64_ecma(password):
+    """CRC-64-ECMA over UTF-16LE, MSB-first, Tacview-style (init=all-1s, final-xor=all-1s)."""
+    if not password:
+        return "0"
+    poly = 0x42F0E1EBA9EA3693
+    data = password.encode("utf-16-le")
+    crc = 0xFFFFFFFFFFFFFFFF
+    for b in data:
+        crc ^= b << 56
+        for _ in range(8):
+            if crc & 0x8000000000000000:
+                crc = (crc << 1) ^ poly
+            else:
+                crc <<= 1
+            crc &= 0xFFFFFFFFFFFFFFFF
+    return format(crc ^ 0xFFFFFFFFFFFFFFFF, "016x")
+
+def run_test(password):
+    """Connect, handshake, and verify ACMI header reception."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(5)
+    s.connect((HOST, PORT))
+
+    handshake = recv_until_null(s)
+    fields = handshake.split(b"\n")
+    assert len(fields) == 4, f"Expected 4 fields, got {len(fields)}"
+    assert fields[0] == b"XtraLib.Stream.0"
+    assert fields[1] == b"Tacview.RealTimeTelemetry.0"
+    print(f"[PASS] Host handshake: {fields[2].decode()}")
+
+    pwd_hash = crc64_ecma(password)
+    s.sendall(
+        f"XtraLib.Stream.0\nTacview.RealTimeTelemetry.0\nTestClient\n{pwd_hash}\0"
+        .encode()
+    )
+
+    time.sleep(0.3)
+    buf = recv_until_lines(s, min_lines=5, timeout=3)
+
+    assert b"FileType=text/acmi/tacview" in buf, "Missing FileType"
+    assert b"FileVersion=2.2" in buf, "Missing FileVersion"
+    assert b"ReferenceTime" in buf, "Missing ReferenceTime"
+    lines = buf.decode().strip().split("\n")
+    print(f"[PASS] ACMI header received ({len(lines)} lines)")
+    for line in lines[:5]:
+        print(f"  > {line}")
+    s.close()
+    return True
+
+def run_test_with_hash(pwd_hash):
+    """Connect and handshake with a specific hash (for no-password mode testing)."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(5)
+    s.connect((HOST, PORT))
+
+    handshake = recv_until_null(s)
+    fields = handshake.split(b"\n")
+    assert fields[0] == b"XtraLib.Stream.0"
+    assert fields[1] == b"Tacview.RealTimeTelemetry.0"
+
+    s.sendall(
+        f"XtraLib.Stream.0\nTacview.RealTimeTelemetry.0\nTestClient\n{pwd_hash}\0"
+        .encode()
+    )
+
+    time.sleep(0.3)
+    buf = recv_until_lines(s, min_lines=3, timeout=3)
+    ok = b"FileType=text/acmi/tacview" in buf
+    s.close()
+    if ok:
+        print(f"[PASS] Hash '{pwd_hash}' accepted (no-password mode)")
+    else:
+        print(f"[FAIL] Hash '{pwd_hash}' rejected unexpectedly")
+    return ok
+
+def test_wrong_password():
+    """Wrong password should cause clean disconnect."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(3)
+    s.connect((HOST, PORT))
+    recv_until_null(s)
+    s.sendall(b"XtraLib.Stream.0\nTacview.RealTimeTelemetry.0\nBadClient\nDEADBEEF\0")
+    time.sleep(0.3)
+    try:
+        resp = s.recv(1024)
+        if resp:
+            print("[FAIL] Wrong password: got data (expected disconnect)")
+            return False
+        print("[PASS] Wrong password: clean close")
+    except (socket.timeout, ConnectionResetError, ConnectionAbortedError):
+        print("[PASS] Wrong password: disconnected as expected")
+    finally:
+        s.close()
+    return True
+
+def recv_until_null(sock):
+    data = b""
+    while True:
+        b = sock.recv(1)
+        if b == b"\0" or not b:
+            break
+        data += b
+    return data
+
+def recv_until_lines(sock, min_lines, timeout=3):
+    buf = b""
+    deadline = time.monotonic() + timeout
+    lines_seen = 0
+    while time.monotonic() < deadline:
+        try:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+            lines_seen = buf.count(b"\n")
+            if lines_seen >= min_lines:
+                break
+        except socket.timeout:
+            break
+    return buf
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--password", default="", help="Server password")
+    args = ap.parse_args()
+
+    ok = True
+
+    if args.password:
+        print("=== Password mode: correct hash ===")
+        ok &= run_test(args.password)
+
+        print("\n=== Password mode: wrong hash ===")
+        ok &= test_wrong_password()
+    else:
+        print("=== No-password mode: hash 0 accepted ===")
+        ok &= run_test("")
+
+        print("\n=== No-password mode: arbitrary hash accepted ===")
+        ok &= run_test_with_hash("DEADBEEF")
+
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
## Summary

Adds a TCP-based Real-Time Telemetry (RTT) server to NOBlackBox, allowing Tacview (Advanced license) to connect during active missions and receive live ACMI 2.2 telemetry streaming.

## Changes

### New: src/RTTTelemetryServer/ — RTT server & client

- **RTTTelemetryServer.cs**: TCP listener on configurable bind address/port (default 127.0.0.1:42674). Session lifecycle (BeginSession -> PublishLine/PublishFlushMarker -> EndSession). Max-clients limiting via interlocked counter. Replay prefix collected and replayed to late-joining clients. Lock scoped to replay-prefix coordination only (hot path lock-free via ConcurrentDictionary).

- **RTTClient.cs**: Handshake with 5s timeout. Password via CRC-64-ECMA over UTF-16LE (empty = accept any). Background writer task consuming ConcurrentQueue with interlocked depth limit. Two-path shutdown: graceful (RequestDisconnect -> drain -> cancel) and abrupt (exception -> RemoveClient). NoDelay enabled, LF-only, UTF-8 no BOM.

### Modified: src/ACMIWriter/ACMIWriter.cs

- Constructor calls rttServer.BeginSession() before header lines.
- WriteLine publishes via rttServer.PublishLine + flush marker on # lines.
- Close() calls rttServer.EndSession(disconnectClients: true).

### Modified: src/Configuration/Configuration.cs

6 new entries under "Real-Time Telemetry" section: LiveTelemetryEnabled, LiveTelemetryBindAddress, LiveTelemetryPort, LiveTelemetryPassword, LiveTelemetryMaxClients, LiveTelemetryClientQueueLimit.

### Modified: src/Helpers/Helpers.cs

- ComputeTacviewPasswordCrc64: CRC-64/ECMA-182 verified against Tacview test vector ("test" -> 38e095a027baf2bc).
- ComputePasswordHash: UTF-16LE encoding + CRC-64.

### Modified: src/Plugin/Plugin.cs

- RTT server created/started in Awake() (try/catch guarded).
- OnDestroy() calls Dispose().
- Static Plugin.rttServer accessible from ACMIWriter.

### Modified: NOBlackBox.csproj

- Condition on HintPath allows NUCLEAR_OPTION_ROOT env var override for CI.

### Other

- .gitignore: added Directory.Build.props
- test_rtt_client.py: Python RTT test client with CRC reference implementation.

## Testing

Tested end-to-end with Tacview connected:
- Handshake (57 bytes), no-password and password modes
- ~14 KB/s (default 0.2s delta) / ~30 KB/s (0.05s delta)
- LF-only line endings, mission transitions, zombie client cleanup
- Max-client limiting, queue-overflow disconnect

## Notes

- Requires Tacview Advanced+ for RTT.
- Bind to 0.0.0.0 for network access.
- CRC-64-ECMA is integrity check, not security.
